### PR TITLE
feat: generate session name

### DIFF
--- a/development/nix-tmux/dev.tmux
+++ b/development/nix-tmux/dev.tmux
@@ -1,15 +1,32 @@
-# dev.tmux
-SESSION="go-dev"
+#!/usr/bin/env bash
+
+# DEFAULT_PORT
+DEFAULT_PORT=8080
+SHELL="zsh"
+
+# Generate random Docker-like name
+generate_session_name() {
+  ADJECTIVES=(happy brave calm eager fancy gentle jolly kind lucky nice proud quick shiny witty bold clever)
+  NOUNS=(tiger panda eagle otter fox whale lion falcon wolf bear koala shark)
+
+  adj=${ADJECTIVES[$RANDOM % ${#ADJECTIVES[@]}]}
+  noun=${NOUNS[$RANDOM % ${#NOUNS[@]}]}
+  echo "${adj}-${noun}-dev"
+}
+
+SESSION=${2:-$(generate_session_name)}
+echo "Using SESSION=$SESSION"
 
 # Check if the session already exists
-tmux has-session -t $SESSION 2>/dev/null
+tmux has-session -t "$SESSION" 2>/dev/null
 
+# Create new sessions [Optional: ZSH default shell]
 if [ $? != 0 ]; then
-  # Create session, split panes
-  tmux new-session -d -s $SESSION
-  tmux split-window -h -t $SESSION
-  tmux split-window -v -t $SESSION
+  tmux new-session -d -s "$SESSION" ${SHELL}
+  tmux split-window -h -t "$SESSION" ${SHELL}
+  tmux split-window -v -t "$SESSION" ${SHELL}
+
+  tmux send-keys -t "$SESSION":0
 fi
 
-# Attach
-tmux attach-session -t $SESSION
+tmux attach-session -t "$SESSION"


### PR DESCRIPTION
feat: custom session

This commit introduces a function `generate_session_name` to create unique session names resembling Docker container names (e.g., "happy-tiger-dev"). This addresses the previous issue of hardcoded session names and provides a more dynamic and descriptive naming scheme.  

The script now generates a random name if a session doesn't exist, creating new sessions with split panes and setting the default shell to zsh.  The `tmux attach-session` command is also updated to use the generated session name.